### PR TITLE
Make arrays readonly and copy before sort

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,5 @@
 export { useOnOutsideClick } from './hooks/useOnOutsideClick';
 export { useFocus } from './hooks/useFocus';
 export { arraysIsEqual } from './utils/arrayUtils';
-export { objectIsEmpty } from './utils/objectUtils';
+export { objectIsEmpty, objectsIsEqual } from './utils/objectUtils';
 export { fireAndForget } from './utils/asyncUtils';

--- a/src/utils/arrayUtils.ts
+++ b/src/utils/arrayUtils.ts
@@ -5,24 +5,26 @@ import { objectsIsEqual } from './objectUtils';
  * Function for recursively checking the equality of two arrays.
  * One can choose to ignore the order of items if
  * ignoreOrder is passed as true.
- * @param {any[]} a1 The first array to consider.
- * @param {any[]} a2 The second array to consider.
+ * @param {ReadonlyArray<unknown>} a1 The first array to consider.
+ * @param {ReadonlyArray<unknown>} a2 The second array to consider.
  * @param {boolean} [ignoreOrder] Flag which decides whether the order should be ignored.
  * @return {*}  {boolean} Returns if the arrays are equal (true) or not (false).
  */
- export const arraysIsEqual = (a1: unknown[], a2: unknown[], ignoreOrder?: boolean): boolean => {
+ export const arraysIsEqual = (a1: ReadonlyArray<unknown>, a2: ReadonlyArray<unknown>, ignoreOrder?: boolean): boolean => {
     if (a1 === a2) return true;
     if (a1 == null || a2 == null) return false;
     if (a1.length !== a2.length) return false;
 
+    const a1Copy = [...a1];
+    const a2Copy = [...a2];
     if (ignoreOrder) {
-        a1.sort();
-        a2.sort();
+        a1Copy.sort();
+        a2Copy.sort();
     }
 
     for (let i = 0; i < a1.length; ++i) {
-        const val1 = a1[i];
-        const val2 = a2[i];
+        const val1 = a1Copy[i];
+        const val2 = a2Copy[i];
 
         if (val1 !== val2) {
             if (Array.isArray(val1) && Array.isArray(val2)) {


### PR DESCRIPTION
arraysIsEqual function mutated arrays sent in if the ignoreOrder flag was set. Fixed this by making it readonly and make copies of arrays before sorting.