### PR TITLE
Feature #35171: Copy/introduce ClassObserver

### DIFF
--- a/src/__tests__/utils/classObserver.test.ts
+++ b/src/__tests__/utils/classObserver.test.ts
@@ -1,0 +1,43 @@
+import classObserver, { ObserverIdentifier } from '../../utils/classObserver';
+
+describe('ClassObserver ', () => {
+    it('Subscriptions', () => {
+        // :: Arrange
+        const func = jest.fn();
+        const typeName = 'someType';
+
+        // :: Act
+        const observerId: ObserverIdentifier = classObserver.addSubscriber(func, typeName);
+
+        // :: Assert
+        expect(observerId).not.toBeNull();
+        expect(observerId).toBeGreaterThan(0);
+    });
+
+    it('notifications', () => {
+        // :: Arrange
+        const func = jest.fn();
+        const typeName = 'someType';
+        classObserver.addSubscriber(func, typeName);
+
+        // :: Act
+        classObserver.notify<string>("hello world", typeName);
+
+        // :: Assert
+        expect(func).toBeCalledWith("hello world");
+    });
+
+    it('Unsubscribe', () => {
+        // :: Arrange
+        const func = jest.fn();
+        const typeName = 'someType';
+        const observerId: ObserverIdentifier = classObserver.addSubscriber(func, typeName);
+
+        // :: Act
+        classObserver.removeSubscriber(observerId);
+        classObserver.notify<string>("hello world", typeName);
+
+        // :: Assert
+        expect(func).not.toBeCalled();        
+    });
+});

--- a/src/__tests__/utils/classObserver.test.ts
+++ b/src/__tests__/utils/classObserver.test.ts
@@ -16,15 +16,19 @@ describe('ClassObserver ', () => {
 
     it('notifications', () => {
         // :: Arrange
-        const func = jest.fn();
+        const firstFunc = jest.fn();
+        const secondFunc = jest.fn();
         const typeName = 'someType';
-        classObserver.addSubscriber(func, typeName);
+        const otherTypeName = 'someOtherType'
+        classObserver.addSubscriber(firstFunc, typeName);
+        classObserver.addSubscriber(secondFunc, otherTypeName);
 
         // :: Act
         classObserver.notify<string>("hello world", typeName);
 
         // :: Assert
-        expect(func).toBeCalledWith("hello world");
+        expect(firstFunc).toBeCalledWith("hello world");
+        expect(secondFunc).not.toBeCalled();
     });
 
     it('Unsubscribe', () => {

--- a/src/utils/classObserver.ts
+++ b/src/utils/classObserver.ts
@@ -1,0 +1,66 @@
+export type ObserverIdentifier = number;
+
+/**
+ * The interface to implement if one wants to use a subscriber pattern on the implementing class.
+ */
+export interface ObserverInterface {
+    id: ObserverIdentifier;
+    callback: Function;
+    type: string;
+}
+
+/**
+ * Utility class to ease usage of a subscription pattern - i.e. if one needs to have subscriptions (callable functions)
+ * from consumers, this helper class will handle it, ensuring that subscribers are being persisted and notified when
+ * required.
+ * 
+ * The class was copied as-is from EchoCore and was written by Hanne Kottum - all credits to her.
+ */
+class ClassObserver {
+    private id: ObserverIdentifier;
+    private observers: ObserverInterface[];
+
+    constructor() {
+        this.id = 0;
+        this.observers = [];
+    }
+
+    /**
+     * Add a subscriber to the observer.
+     * Later the implementing class can call {@link notify} to notify all subscribers of a given type. 
+     * @param callback the callback function to be called on {@link notify}
+     * @param type the "type" of subscriber
+     * @returns {@link ObserverIdentifier}, a unique id identifying the subscriber
+     */
+    addSubscriber(callback: Function, type: string): ObserverIdentifier {
+        this.id++;
+        const functionCallback = { id: this.id, callback, type };
+        this.observers.push(functionCallback);
+        return this.id;
+    }
+
+    /**
+     * Remove the given subscriber from receiving further notifications.
+     * @param id the {@link ObserverIdentifier} of the subscriber, as obtained from {@link addSubscriber}
+     */
+    removeSubscriber(id: ObserverIdentifier): void {
+        this.observers = this.observers.filter((item) => item.id !== id);
+    }
+
+    /**
+     * Notify any subscribers with the given type and using the given data.
+     * @param data The data to use as a parameter in the callback function for the subscribers,
+     * @param type The type of subscriber
+     */
+    notify<T>(data: T, type: string): void {
+        this.observers.forEach((observer) => {
+            if (observer.type === type) {
+                observer.callback(data);
+            }
+        });
+    }
+}
+
+export default new ClassObserver();
+
+export const ObserverClass = ClassObserver;


### PR DESCRIPTION
Copying the classObserver utility from EchoCore as-is and adding tests.

The rationale of copying the utilty is that one does want to make a direct dependency from EchoUtils to EchoCore (but one might argue that one later will do the other way round).
This utility is needed when copying the logger-class from EchoWeb to EchoUtils.


Adding unit-tests and documentation which were missing.