### PR TITLE
Feature #35171: Introducing/copying logger from EchoWeb

### DIFF
--- a/src/__tests__/utils/logger.test.ts
+++ b/src/__tests__/utils/logger.test.ts
@@ -1,0 +1,293 @@
+import { addLogSubscriber, logError, logInfo, logMSAL, logPerformanceToConsole, logVerbose, logWarn, removeLogSubscriber, setLoggerConfiguration } from '../../utils/logger';
+
+// Mock the time helpers so that we can control the timing in the tests
+// Do note that we seemingly need to have the jest.mock _before_ the import statement to have thing work properly...
+jest.mock('../../utils/formatTimeHelpers');
+import { ElapsedTimeInSeconds } from '../../utils/formatTimeHelpers';
+
+describe('Logger behaves as expected', () => {
+    let logSpy, warnSpy, errorSpy;
+    
+    const mockElapsedTimeInSeconds = ElapsedTimeInSeconds as jest.Mock;
+
+    beforeEach(() => {
+        logSpy = jest.spyOn(console, 'log');
+        warnSpy = jest.spyOn(console, 'warn');
+        errorSpy = jest.spyOn(console, 'error');
+    });
+
+    afterEach(() => {
+        logSpy.mockReset();
+        warnSpy.mockReset();
+        errorSpy.mockReset();
+        mockElapsedTimeInSeconds.mockReset();
+    });
+    
+    it('when log flag is set to disabled does not log anything', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: false,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: false,
+            isMSALLoggingEnabled: false
+        });
+
+        // :: Act
+        logInfo('Hello', 'World');
+        logWarn('Hello', 'World');
+        logError('Hello', 'World');
+
+        // :: Assert
+        expect(logSpy).not.toBeCalled();
+        expect(warnSpy).not.toBeCalled();
+        expect(errorSpy).not.toBeCalled();
+    });
+
+    it('logInfo', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: false,
+            isMSALLoggingEnabled: false
+        });
+
+        // :: Act
+        logInfo('Hello', 'World');
+
+        // :: Assert
+        expect(logSpy).toHaveBeenCalledWith('Hello', 'World');
+        expect(warnSpy).not.toBeCalled();
+        expect(errorSpy).not.toBeCalled();
+    });
+
+    it('logWarn', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: false,
+            isMSALLoggingEnabled: false
+        });
+
+        // :: Act
+        logWarn('Hello', 'World');
+
+        // :: Assert
+        expect(logSpy).not.toBeCalled();
+        expect(warnSpy).toHaveBeenCalledWith('Hello', 'World');
+        expect(errorSpy).not.toBeCalled();
+    });
+
+    it('logError', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: false,
+            isMSALLoggingEnabled: false
+        });
+
+        // :: Act
+        logError('Hello', 'World');
+
+        // :: Assert
+        expect(logSpy).not.toBeCalled();
+        expect(warnSpy).not.toBeCalled();
+        expect(errorSpy).toHaveBeenCalledWith('Hello', 'World');
+    });
+
+    it('logVerbose', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: false,
+            isMSALLoggingEnabled: false
+        });
+
+        // :: Act
+        logVerbose('Hello', 'World');
+
+        // :: Assert
+        expect(logSpy).toHaveBeenCalledWith('Hello', 'World');
+        expect(warnSpy).not.toBeCalled();
+        expect(errorSpy).not.toBeCalled();
+    });
+
+    it('logMSAL enabled should log', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: false,
+            isMSALLoggingEnabled: true
+        });
+
+        // :: Act
+        logMSAL('Hello', 'World');
+
+        // :: Assert
+        expect(logSpy).toHaveBeenCalledWith('Hello', 'World');
+        expect(warnSpy).not.toBeCalled();
+        expect(errorSpy).not.toBeCalled();
+    });
+
+    it('logMSAL disabled should not log', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: false,
+            isMSALLoggingEnabled: false
+        });
+
+        // :: Act
+        logMSAL('Hello', 'World');
+
+        // :: Assert
+        expect(logSpy).not.toBeCalled();
+        expect(warnSpy).not.toBeCalled();
+        expect(errorSpy).not.toBeCalled();
+    });
+
+    it('logPerformanceToConsole GREEN', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: false,
+            isMSALLoggingEnabled: false
+        });
+        
+        mockElapsedTimeInSeconds.mockReturnValue(0.1);
+
+        // :: Act
+        logPerformanceToConsole('This is quite fast', 1000);
+
+        // :: Assert
+        expect(logSpy).toHaveBeenCalledWith(
+            '%c%s %c%s',
+            `color: black;`,
+            'This is quite fast',
+            'color: green;',
+            (0.1).toFixed(3) + ' sec(s)'
+        );
+        expect(warnSpy).not.toBeCalled();
+        expect(errorSpy).not.toBeCalled();
+    });
+
+    it('logPerformanceToConsole YELLOW', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: false,
+            isMSALLoggingEnabled: false
+        });
+        
+        mockElapsedTimeInSeconds.mockReturnValue(0.4);
+
+        // :: Act
+        logPerformanceToConsole('This is not so fast', 1000);
+
+        // :: Assert
+        expect(logSpy).toHaveBeenCalledWith(
+            '%c%s %c%s',
+            `color: black;`,
+            'This is not so fast',
+            'color: orange;',
+            (0.4).toFixed(3) + ' sec(s)'
+        );
+        expect(warnSpy).not.toBeCalled();
+        expect(errorSpy).not.toBeCalled();
+    });
+    
+    it('logPerformanceToConsole RED', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: false,
+            isMSALLoggingEnabled: false
+        });
+        
+        mockElapsedTimeInSeconds.mockReturnValue(1.23456);
+
+        // :: Act
+        logPerformanceToConsole('SLOOOOW!', 1000);
+
+        // :: Assert
+        expect(logSpy).toHaveBeenCalledWith(
+            '%c%s %c%s',
+            `color: black;`,
+            'SLOOOOW!',
+            'color: red;',
+            (1.23456).toFixed(3) + ' sec(s)'
+        );
+        expect(warnSpy).not.toBeCalled();
+        expect(errorSpy).not.toBeCalled();
+    });
+});
+
+describe('LogSubscriptions behaves as expected', () => {
+    it('addSubscribers with notifyLogSubscribers enabled', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: true,
+            isMSALLoggingEnabled: false
+        });
+        const subscriberCallback = jest.fn();
+
+        // :: Act
+        const subscriberId = addLogSubscriber(subscriberCallback);
+        logInfo('Hello');
+        logWarn('World');
+        logError('!');
+
+        // :: Assert
+        expect(subscriberCallback).toBeCalledTimes(3);
+        expect(subscriberCallback).toBeCalledWith(['Hello']);
+        expect(subscriberCallback).toBeCalledWith(['World']);
+        expect(subscriberCallback).toBeCalledWith(['!']);
+
+        expect(subscriberId).toBeGreaterThan(0);
+    });
+
+    describe('LogSubscriptions no notifications after unsubscribe ', () => {
+        it('addSubscribers with notifyLogSubscribers enabled', () => {
+            // :: Arrange
+            setLoggerConfiguration({
+                isEnabled: true,
+                isDevelopment: false,
+                logWithStackTrace: false,
+                notifyLogSubscribers: true,
+                isMSALLoggingEnabled: false
+            });
+            const subscriberCallback = jest.fn();
+    
+            // :: Act
+            const subscriberId = addLogSubscriber(subscriberCallback);
+            removeLogSubscriber(subscriberId);
+            logInfo('Hello');
+            logWarn('World');
+            logError('!');
+    
+            // :: Assert
+            expect(subscriberCallback).not.toBeCalled();
+        });
+    });
+});

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,139 @@
+import { ObserverClass, ObserverIdentifier } from './classObserver';
+import { ElapsedTimeInSeconds } from './formatTimeHelpers';
+
+/**
+ * Log configuration
+ */
+ let config = {
+    isEnabled: false,
+    logWithStackTrace: false,
+    notifyLogSubscribers: false,
+    isDevelopment: false,
+    isMSALLoggingEnabled: false
+} as LoggerConfiguration;
+
+/**
+ * Internal helper class to keep track of any log-subscribers.
+ */
+class LogSubscribers extends ObserverClass {
+    constructor() {
+        super();
+    }
+}
+// The ObserverClass needs a "type" on each subscription. Consumers of the logger (i.e. logSubscriptions) do not 
+// need to know about this and we just assign the same "type" to all subscribers; this one. 
+const LogSubscriberType : string  = 'LogSubscriberType';
+const logSubscribers : LogSubscribers = new LogSubscribers();
+
+/**
+ * Add a subscriber to the given type. If the configuration is setup to notify subscribers, then the callback
+ * given here will be called if a logging is performed on the given type.
+ * @param callback 
+ * @returns a unique identifier for the subscriber which later can be used in {@link removeLogSubscriber}.
+ */
+export function addLogSubscriber(callback: Function) : ObserverIdentifier {
+    return logSubscribers.addSubscriber(callback, LogSubscriberType);
+}
+
+/**
+ * Remove the given log-subscriber from receiving any further log-notifications.
+ * @param identifier The identifier as obtained from {@link addLogSubscriber}
+ */
+export function removeLogSubscriber(identifier : ObserverIdentifier) {
+    logSubscribers.removeSubscriber(identifier);
+}
+
+export interface LoggerConfiguration {
+    isEnabled: boolean;
+    isDevelopment: boolean;
+    logWithStackTrace: boolean;
+    notifyLogSubscribers: boolean;
+    isMSALLoggingEnabled: boolean;
+}
+
+export function setLoggerConfiguration(loggerConfiguration: LoggerConfiguration): void {
+    config = loggerConfiguration;
+}
+
+enum LogType {
+    Info,
+    Warn,
+    Error,
+    Verbose
+}
+
+export function logMSAL(...args: any[]): void {
+    if (config.isMSALLoggingEnabled) {
+        localLog(LogType.Info, ...args);
+    }
+}
+
+export function logVerbose(...args: any[]): void {
+    localLog(LogType.Verbose, ...args);
+}
+
+export function logInfo(...args: any[]): void {
+    localLog(LogType.Info, ...args);
+}
+
+export function logWarn(...args: any[]): void {
+    localLog(LogType.Warn, ...args);
+}
+
+export function logError(...args: any[]): void {
+    localLog(LogType.Error, ...args);
+}
+
+const isMac = (): boolean => {
+    const mac = /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform);
+    return mac;
+};
+
+function getStackCallerFunctionName(err: any): string {
+    let caller = err.stack.includes('logErrorToAppInsights')
+        ? err.stack.split('\n')[9]
+        : err.stack.includes('postNotification')
+        ? err.stack.split('\n')[6]
+        : err.stack.includes('logPerformanceToConsole')
+        ? err.stack.split('\n')[4]
+        : err.stack.split('\n')[3];
+    if (!isMac() && String(caller).includes('at')) caller = caller.split('at ')[1].split(' (')[0];
+    return caller;
+}
+
+function localLog(logType: LogType, ...args: any[]): void {
+    if (!config.isEnabled) {
+        return;
+    }
+    
+    if (config.notifyLogSubscribers) {
+        logSubscribers.notify(args, LogSubscriberType);
+    }
+
+    if (config.logWithStackTrace && config.isDevelopment) {
+        try {
+            throw new Error();
+        } catch (err) {
+            const callerName = getStackCallerFunctionName(err);
+            logWithType(logType, ...args, `[${callerName}]`); //callerName at the end to get colors to work
+        }
+    } else {
+        logWithType(logType, ...args);
+    }
+}
+
+function logWithType(logType: LogType, ...args: any[]): void {
+    if (logType === LogType.Info) console.log(...args);
+    else if (logType === LogType.Warn) console.warn(...args);
+    else if (logType === LogType.Error) console.error(...args);
+    else if (logType === LogType.Verbose) console.log(...args);
+}
+
+export function logPerformanceToConsole(message: string, startTime: number): void {
+    const timeInSeconds = ElapsedTimeInSeconds(startTime);
+    let color = 'green';
+    if (timeInSeconds > 0.3) color = 'orange';
+    if (timeInSeconds > 1) color = 'red';
+
+    logVerbose('%c%s %c%s', `color: black;`, message, `color: ${color};`, timeInSeconds.toFixed(3) + ' sec(s)');
+}


### PR DESCRIPTION
Copying the logger utility from EchoWeb, removing the component
dependency and implementing a subscription pattern instead.

Adding tests.


Do note, this branch has dependencies on other brances on the same feature - so might not yet build...
Will merge the others later and do a pull&push on this branch.