### PR TITLE
Feature #35171: Move logger and its dependencies from EchoWeb

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,8 @@
 module.exports = {
     coveragePathIgnorePatterns: ['src/types/*', 'src/index.ts'],
     collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!<rootDir>/node_modules/'],
+    collectCoverage: true,
+    coverageDirectory: 'coverage',
     coverageThreshold: {
         global: {
             lines: 90,

--- a/src/__tests__/utils/classObserver.test.ts
+++ b/src/__tests__/utils/classObserver.test.ts
@@ -1,0 +1,47 @@
+import classObserver, { ObserverIdentifier } from '../../utils/classObserver';
+
+describe('ClassObserver ', () => {
+    it('Subscriptions', () => {
+        // :: Arrange
+        const func = jest.fn();
+        const typeName = 'someType';
+
+        // :: Act
+        const observerId: ObserverIdentifier = classObserver.addSubscriber(func, typeName);
+
+        // :: Assert
+        expect(observerId).not.toBeNull();
+        expect(observerId).toBeGreaterThan(0);
+    });
+
+    it('notifications', () => {
+        // :: Arrange
+        const firstFunc = jest.fn();
+        const secondFunc = jest.fn();
+        const typeName = 'someType';
+        const otherTypeName = 'someOtherType'
+        classObserver.addSubscriber(firstFunc, typeName);
+        classObserver.addSubscriber(secondFunc, otherTypeName);
+
+        // :: Act
+        classObserver.notify<string>("hello world", typeName);
+
+        // :: Assert
+        expect(firstFunc).toBeCalledWith("hello world");
+        expect(secondFunc).not.toBeCalled();
+    });
+
+    it('Unsubscribe', () => {
+        // :: Arrange
+        const func = jest.fn();
+        const typeName = 'someType';
+        const observerId: ObserverIdentifier = classObserver.addSubscriber(func, typeName);
+
+        // :: Act
+        classObserver.removeSubscriber(observerId);
+        classObserver.notify<string>("hello world", typeName);
+
+        // :: Assert
+        expect(func).not.toBeCalled();        
+    });
+});

--- a/src/__tests__/utils/formatTimeHelpers.test.ts
+++ b/src/__tests__/utils/formatTimeHelpers.test.ts
@@ -1,0 +1,218 @@
+import { dateToStringOrEmpty, diffHours, diffMinutes, ElapsedTimeInSeconds, elapsedTimeInSecondsBetween, ElapsedTimeInSecondsToFixed } from "../../utils/formatTimeHelpers";
+
+
+describe('diffHours', () => {
+    it('2.5 hour difference should return 2 hours', () => {
+        const date1 = new Date('2020-01-20T00:00:00');
+        const date2 = new Date('2020-01-20T02:30:00');
+        const result = diffHours(date1, date2);
+        expect(result).toEqual(2);
+    });
+    it('should handle 3 hours difference from between today and yesterday', () => {
+        const date1 = new Date('2020-01-19T23:00:00');
+        const date2 = new Date('2020-01-20T02:00:00');
+        const result = diffHours(date1, date2);
+        expect(result).toEqual(3);
+    });
+    it('should ignore minutes and seconds', () => {
+        const date1 = new Date('2020-01-19T00:00:00');
+        const date2 = new Date('2020-01-19T01:13:27');
+        const result = diffHours(date1, date2);
+        expect(result).toEqual(1);
+    });
+
+    it('should handle 1 hours difference from dates that are strings from json parsing', () => {
+        const dates = parseJsonDates('2020-01-19T00:00:00', '2020-01-19T01:00:00');
+        const result = diffHours(dates.date1, dates.date2);
+        expect(result).toEqual(1);
+    });
+
+    it('invalid date from json parsing should return undefined', () => {
+        const dates = parseJsonDates('', '2020-01-19T01:00:00');
+        const result = diffHours(dates.date1, dates.date2);
+        expect(result).toEqual(undefined);
+        const dates2 = parseJsonDates('2020-01-19T01:00:00', 'invalid date');
+        const result2 = diffHours(dates2.date1, dates2.date2);
+        expect(result2).toEqual(undefined);
+    });
+});
+
+describe('diffMinutes', () => {
+    it('1.25 hour difference should return 2 minutes', () => {
+        const date1 = new Date('2020-01-20T00:00:00');
+        const date2 = new Date('2020-01-20T01:15:00');
+        const result = diffMinutes(date1, date2);
+        expect(result).toEqual(75);
+    });
+    it('should handle 3.5 hours difference from between today and yesterday', () => {
+        const date1 = new Date('2020-01-19T23:00:00');
+        const date2 = new Date('2020-01-20T02:30:00');
+        const result = diffMinutes(date1, date2);
+        expect(result).toEqual(210);
+    });
+    it('should ignore seconds', () => {
+        const date1 = new Date('2020-01-19T00:00:00');
+        const date2 = new Date('2020-01-19T00:10:23');
+        const result = diffMinutes(date1, date2);
+        expect(result).toEqual(10);
+    });
+
+    it('should handle 1 hours difference from dates that are strings from json parsing', () => {
+        const dates = parseJsonDates('2020-01-19T00:00:00', '2020-01-19T01:00:00');
+        const result = diffMinutes(dates.date1, dates.date2);
+        expect(result).toEqual(60);
+    });
+
+    it('invalid date from json parsing should return undefined', () => {
+        const dates = parseJsonDates('', '2020-01-19T01:00:00');
+        const result = diffMinutes(dates.date1, dates.date2);
+        expect(result).toEqual(undefined);
+        const dates2 = parseJsonDates('2020-01-19T01:00:00', 'invalid date');
+        const result2 = diffMinutes(dates2.date1, dates2.date2);
+        expect(result2).toEqual(undefined);
+    });
+});
+
+describe('ElapsedTimeInSecondsBetween', () => {
+    it('10 000 milliseconds difference should return 10 seconds elapsed', () => {
+        const fromMs = 0;
+        const toMs = 10000;
+        const elapsedSeconds10 = elapsedTimeInSecondsBetween(fromMs, toMs);
+        expect(elapsedSeconds10).toEqual(10);
+    });
+    it('should handled mixed up order of input parameters', () => {
+        const fromMs = 5000;
+        const toMs = 0;
+        let elapsedSeconds5 = elapsedTimeInSecondsBetween(fromMs, toMs);
+        expect(elapsedSeconds5).toEqual(5);
+        elapsedSeconds5 = elapsedTimeInSecondsBetween(toMs, fromMs);
+        expect(elapsedSeconds5).toEqual(5);
+    });
+});
+
+describe('dateToStringOrEmpty tests', () => {
+    it('should return empty string if undefined', () => {
+        const actualDate = dateToStringOrEmpty(undefined);
+        expect(actualDate).toEqual('');
+    });
+    it('should handle string which is not a date, and return Invalid Date', () => {
+        const actualDate = dateToStringOrEmpty('garbage string');
+        expect(actualDate).toEqual('Invalid Date');
+    });
+    it('should return empty if epoch date is 1/1/1970 00:00:00', () => {
+        const date = '1970-01-01';
+        const actualDate = dateToStringOrEmpty(date);
+        expect(actualDate).toEqual('');
+    });
+    it('should convert a string date to human readable string', () => {
+        const date = '2020-02-19T13:00:00';
+        const actualDate = dateToStringOrEmpty(date);
+        //local format varies between browser, jest, and azure, so let's just make sure we include all correct date time values
+        expect(actualDate).toContain('13:00:00');
+        expect(actualDate).toContain('2020');
+        expect(actualDate).toContain('19');
+        expect(actualDate).toContain('2');
+        expect(actualDate).not.toContain('T');
+    });
+    it('should convert a real date to human readable string', () => {
+        const date = new Date('2020-02-19T13:00:00');
+        console.log('is failing', date.toISOString());
+        const actualDate = dateToStringOrEmpty(date);
+        expect(actualDate).toContain('13:00:00');
+        expect(actualDate).toContain('2020');
+        expect(actualDate).toContain('19');
+        expect(actualDate).toContain('2');
+        expect(actualDate).not.toContain('T');
+    });
+    it('should convert a json string disguised as date to human readable string', () => {
+        const date = parseJsonDates('2020-02-19T13:00:00', '2020-02-19T13:00:00');
+        const actualDate = dateToStringOrEmpty(date.date1);
+        expect(actualDate).toContain('13:00:00');
+        expect(actualDate).toContain('2020');
+        expect(actualDate).toContain('19');
+        expect(actualDate).toContain('2');
+        expect(actualDate).not.toContain('T');
+    });
+    it('midnight 00h should result in only current date being returned', () => {
+        const date = '2021-03-19T00:00:00';
+        const actualDate = dateToStringOrEmpty(date);
+        expect(actualDate).not.toContain('00:00:00');
+        expect(actualDate).toContain('2021');
+        expect(actualDate).toContain('19');
+        expect(actualDate).toContain('3');
+        expect(actualDate).not.toContain('T');
+    });
+    it('midnight 24h should result in next date being returned', () => {
+        const date = '2021-03-19T24:00:00';
+        const actualDate = dateToStringOrEmpty(date);
+        expect(actualDate).not.toContain('24:00:00');
+        expect(actualDate).toContain('2021');
+        expect(actualDate).toContain('20');
+        expect(actualDate).toContain('3');
+        expect(actualDate).not.toContain('T');
+    });
+});
+
+describe('ElapsedTimeInSeconds tests', () => {
+    it('should return expected 5 seconds for given input', () => {
+        const startTimeInMs = 2_000; 
+        const endTimeInMs = 7_000;
+        performance.now = jest.fn(() => endTimeInMs);
+        const inSeconds = ElapsedTimeInSeconds(startTimeInMs);
+        expect(inSeconds).toEqual(5);
+    });
+
+    it('should return expected seconds with decimals for given input', () => {
+        const startTimeInMs = 2_000; 
+        const endTimeInMs = 7_123;
+        performance.now = jest.fn(() => endTimeInMs);
+        const inSeconds = ElapsedTimeInSeconds(startTimeInMs);
+        expect(inSeconds).toEqual(5.123);
+    });
+});
+
+describe('ElapsedTimeInSecondsToFixed tests', () => {
+    it('ElapsedTimeInSecondsToFixed defaults to 2 decimals', () => {
+        const startTimeInMs = 2_000; 
+        const endTimeInMs = 7_123;
+        performance.now = jest.fn(() => endTimeInMs);
+        const inSeconds = ElapsedTimeInSecondsToFixed(startTimeInMs);
+        expect(inSeconds).toEqual(5.12);
+    });
+
+    it('ElapsedTimeInSecondsToFixed does default rounding as expected', () => {
+        const startTimeInMs = 2_000; 
+        const endTimeInMs = 3_005;
+        performance.now = jest.fn(() => endTimeInMs);
+        const inSeconds = ElapsedTimeInSecondsToFixed(startTimeInMs);
+        expect(inSeconds).toEqual(1.01);
+    });
+
+    it('ElapsedTimeInSecondsToFixed uses fixed number of decimals', () => {
+        const startTimeInMs = 2_000; 
+        const endTimeInMs = 7_000;
+        performance.now = jest.fn(() => endTimeInMs);
+        const inSeconds = ElapsedTimeInSecondsToFixed(startTimeInMs);
+        expect(inSeconds).toEqual(5.00);
+    });
+
+    it('ElapsedTimeInSecondsToFixed returns number of decimals according to input', () => {
+        const startTimeInMs = 2_000; 
+        const endTimeInMs = 7_123.456;
+        performance.now = jest.fn(() => endTimeInMs);
+        const inSeconds = ElapsedTimeInSecondsToFixed(startTimeInMs, 4);
+        expect(inSeconds).toEqual(5.1235);
+    });
+});
+
+
+function parseJsonDates(dateString1: string, dateString2: string): DateInterface {
+    const json = `{"date1": "${dateString1}", "date2": "${dateString2}"}`;
+    const dates = JSON.parse(json) as DateInterface;
+    return dates;
+}
+
+interface DateInterface {
+    date1: Date;
+    date2: Date;
+}

--- a/src/__tests__/utils/formatTimeHelpers.test.ts
+++ b/src/__tests__/utils/formatTimeHelpers.test.ts
@@ -1,4 +1,4 @@
-import { dateToStringOrEmpty, diffHours, diffMinutes, ElapsedTimeInSeconds, elapsedTimeInSecondsBetween, ElapsedTimeInSecondsToFixed } from "../../utils/formatTimeHelpers";
+import { dateToStringOrEmpty, diffHours, diffMinutes, elapsedTimeInSeconds, elapsedTimeInSecondsBetween, elapsedTimeInSecondsToFixed } from "../../utils/formatTimeHelpers";
 
 
 describe('diffHours', () => {
@@ -73,7 +73,7 @@ describe('diffMinutes', () => {
     });
 });
 
-describe('ElapsedTimeInSecondsBetween', () => {
+describe('elapsedTimeInSecondsBetween', () => {
     it('10 000 milliseconds difference should return 10 seconds elapsed', () => {
         const fromMs = 0;
         const toMs = 10000;
@@ -153,12 +153,12 @@ describe('dateToStringOrEmpty tests', () => {
     });
 });
 
-describe('ElapsedTimeInSeconds tests', () => {
+describe('elapsedTimeInSeconds tests', () => {
     it('should return expected 5 seconds for given input', () => {
         const startTimeInMs = 2_000; 
         const endTimeInMs = 7_000;
         performance.now = jest.fn(() => endTimeInMs);
-        const inSeconds = ElapsedTimeInSeconds(startTimeInMs);
+        const inSeconds = elapsedTimeInSeconds(startTimeInMs);
         expect(inSeconds).toEqual(5);
     });
 
@@ -166,41 +166,41 @@ describe('ElapsedTimeInSeconds tests', () => {
         const startTimeInMs = 2_000; 
         const endTimeInMs = 7_123;
         performance.now = jest.fn(() => endTimeInMs);
-        const inSeconds = ElapsedTimeInSeconds(startTimeInMs);
+        const inSeconds = elapsedTimeInSeconds(startTimeInMs);
         expect(inSeconds).toEqual(5.123);
     });
 });
 
-describe('ElapsedTimeInSecondsToFixed tests', () => {
-    it('ElapsedTimeInSecondsToFixed defaults to 2 decimals', () => {
+describe('elapsedTimeInSecondsToFixed tests', () => {
+    it('elapsedTimeInSecondsToFixed defaults to 2 decimals', () => {
         const startTimeInMs = 2_000; 
         const endTimeInMs = 7_123;
         performance.now = jest.fn(() => endTimeInMs);
-        const inSeconds = ElapsedTimeInSecondsToFixed(startTimeInMs);
+        const inSeconds = elapsedTimeInSecondsToFixed(startTimeInMs);
         expect(inSeconds).toEqual(5.12);
     });
 
-    it('ElapsedTimeInSecondsToFixed does default rounding as expected', () => {
+    it('elapsedTimeInSecondsToFixed does default rounding as expected', () => {
         const startTimeInMs = 2_000; 
         const endTimeInMs = 3_005;
         performance.now = jest.fn(() => endTimeInMs);
-        const inSeconds = ElapsedTimeInSecondsToFixed(startTimeInMs);
+        const inSeconds = elapsedTimeInSecondsToFixed(startTimeInMs);
         expect(inSeconds).toEqual(1.01);
     });
 
-    it('ElapsedTimeInSecondsToFixed uses fixed number of decimals', () => {
+    it('elapsedTimeInSecondsToFixed uses fixed number of decimals', () => {
         const startTimeInMs = 2_000; 
         const endTimeInMs = 7_000;
         performance.now = jest.fn(() => endTimeInMs);
-        const inSeconds = ElapsedTimeInSecondsToFixed(startTimeInMs);
+        const inSeconds = elapsedTimeInSecondsToFixed(startTimeInMs);
         expect(inSeconds).toEqual(5.00);
     });
 
-    it('ElapsedTimeInSecondsToFixed returns number of decimals according to input', () => {
+    it('elapsedTimeInSecondsToFixed returns number of decimals according to input', () => {
         const startTimeInMs = 2_000; 
         const endTimeInMs = 7_123.456;
         performance.now = jest.fn(() => endTimeInMs);
-        const inSeconds = ElapsedTimeInSecondsToFixed(startTimeInMs, 4);
+        const inSeconds = elapsedTimeInSecondsToFixed(startTimeInMs, 4);
         expect(inSeconds).toEqual(5.1235);
     });
 });

--- a/src/__tests__/utils/logger.test.ts
+++ b/src/__tests__/utils/logger.test.ts
@@ -3,12 +3,12 @@ import { addLogSubscriber, logError, logInfo, logMSAL, logPerformanceToConsole, 
 // Mock the time helpers so that we can control the timing in the tests
 // Do note that we seemingly need to have the jest.mock _before_ the import statement to have thing work properly...
 jest.mock('../../utils/formatTimeHelpers');
-import { ElapsedTimeInSeconds } from '../../utils/formatTimeHelpers';
+import { elapsedTimeInSeconds } from '../../utils/formatTimeHelpers';
 
 describe('Logger behaves as expected', () => {
     let logSpy, warnSpy, errorSpy;
     
-    const mockElapsedTimeInSeconds = ElapsedTimeInSeconds as jest.Mock;
+    const mockElapsedTimeInSeconds = elapsedTimeInSeconds as jest.Mock;
 
     beforeEach(() => {
         logSpy = jest.spyOn(console, 'log');

--- a/src/__tests__/utils/logger.test.ts
+++ b/src/__tests__/utils/logger.test.ts
@@ -1,0 +1,291 @@
+import { addLogSubscriber, logError, logInfo, logMSAL, logPerformanceToConsole, logVerbose, logWarn, removeLogSubscriber, setLoggerConfiguration } from '../../utils/logger';
+
+// Mock the time helpers so that we can control the timing in the tests
+// Do note that we seemingly need to have the jest.mock _before_ the import statement to have thing work properly...
+jest.mock('../../utils/formatTimeHelpers');
+import { ElapsedTimeInSeconds } from '../../utils/formatTimeHelpers';
+
+describe('Logger behaves as expected', () => {
+    let logSpy, warnSpy, errorSpy;
+    
+    const mockElapsedTimeInSeconds = ElapsedTimeInSeconds as jest.Mock;
+
+    beforeEach(() => {
+        logSpy = jest.spyOn(console, 'log');
+        warnSpy = jest.spyOn(console, 'warn');
+        errorSpy = jest.spyOn(console, 'error');
+    });
+
+    afterEach(() => {
+        logSpy.mockReset();
+        warnSpy.mockReset();
+        errorSpy.mockReset();
+        mockElapsedTimeInSeconds.mockReset();
+    });
+    
+    it('when log flag is set to disabled does not log anything', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: false,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: false,
+            isMSALLoggingEnabled: false
+        });
+
+        // :: Act
+        logInfo('Hello', 'World');
+        logWarn('Hello', 'World');
+        logError('Hello', 'World');
+
+        // :: Assert
+        expect(logSpy).not.toBeCalled();
+        expect(warnSpy).not.toBeCalled();
+        expect(errorSpy).not.toBeCalled();
+    });
+
+    it('logInfo', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: false,
+            isMSALLoggingEnabled: false
+        });
+
+        // :: Act
+        logInfo('Hello', 'World');
+
+        // :: Assert
+        expect(logSpy).toHaveBeenCalledWith('Hello', 'World');
+        expect(warnSpy).not.toBeCalled();
+        expect(errorSpy).not.toBeCalled();
+    });
+
+    it('logWarn', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: false,
+            isMSALLoggingEnabled: false
+        });
+
+        // :: Act
+        logWarn('Hello', 'World');
+
+        // :: Assert
+        expect(logSpy).not.toBeCalled();
+        expect(warnSpy).toHaveBeenCalledWith('Hello', 'World');
+        expect(errorSpy).not.toBeCalled();
+    });
+
+    it('logError', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: false,
+            isMSALLoggingEnabled: false
+        });
+
+        // :: Act
+        logError('Hello', 'World');
+
+        // :: Assert
+        expect(logSpy).not.toBeCalled();
+        expect(warnSpy).not.toBeCalled();
+        expect(errorSpy).toHaveBeenCalledWith('Hello', 'World');
+    });
+
+    it('logVerbose', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: false,
+            isMSALLoggingEnabled: false
+        });
+
+        // :: Act
+        logVerbose('Hello', 'World');
+
+        // :: Assert
+        expect(logSpy).toHaveBeenCalledWith('Hello', 'World');
+        expect(warnSpy).not.toBeCalled();
+        expect(errorSpy).not.toBeCalled();
+    });
+
+    it('logMSAL enabled should log', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: false,
+            isMSALLoggingEnabled: true
+        });
+
+        // :: Act
+        logMSAL('Hello', 'World');
+
+        // :: Assert
+        expect(logSpy).toHaveBeenCalledWith('Hello', 'World');
+        expect(warnSpy).not.toBeCalled();
+        expect(errorSpy).not.toBeCalled();
+    });
+
+    it('logMSAL disabled should not log', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: false,
+            isMSALLoggingEnabled: false
+        });
+
+        // :: Act
+        logMSAL('Hello', 'World');
+
+        // :: Assert
+        expect(logSpy).not.toBeCalled();
+        expect(warnSpy).not.toBeCalled();
+        expect(errorSpy).not.toBeCalled();
+    });
+
+    it('logPerformanceToConsole GREEN', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: false,
+            isMSALLoggingEnabled: false
+        });
+        
+        mockElapsedTimeInSeconds.mockReturnValue(0.1);
+
+        // :: Act
+        logPerformanceToConsole('This is quite fast', 1000);
+
+        // :: Assert
+        expect(logSpy).toHaveBeenCalledWith(
+            '%c%s %c%s',
+            `color: black;`,
+            'This is quite fast',
+            'color: green;',
+            (0.1).toFixed(3) + ' sec(s)'
+        );
+        expect(warnSpy).not.toBeCalled();
+        expect(errorSpy).not.toBeCalled();
+    });
+
+    it('logPerformanceToConsole YELLOW', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: false,
+            isMSALLoggingEnabled: false
+        });
+        
+        mockElapsedTimeInSeconds.mockReturnValue(0.4);
+
+        // :: Act
+        logPerformanceToConsole('This is not so fast', 1000);
+
+        // :: Assert
+        expect(logSpy).toHaveBeenCalledWith(
+            '%c%s %c%s',
+            `color: black;`,
+            'This is not so fast',
+            'color: orange;',
+            (0.4).toFixed(3) + ' sec(s)'
+        );
+        expect(warnSpy).not.toBeCalled();
+        expect(errorSpy).not.toBeCalled();
+    });
+    
+    it('logPerformanceToConsole RED', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: false,
+            isMSALLoggingEnabled: false
+        });
+        
+        mockElapsedTimeInSeconds.mockReturnValue(1.23456);
+
+        // :: Act
+        logPerformanceToConsole('SLOOOOW!', 1000);
+
+        // :: Assert
+        expect(logSpy).toHaveBeenCalledWith(
+            '%c%s %c%s',
+            `color: black;`,
+            'SLOOOOW!',
+            'color: red;',
+            (1.23456).toFixed(3) + ' sec(s)'
+        );
+        expect(warnSpy).not.toBeCalled();
+        expect(errorSpy).not.toBeCalled();
+    });
+});
+
+describe('LogSubscriptions behaves as expected', () => {
+    it('addSubscribers with notifyLogSubscribers enabled', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: true,
+            isMSALLoggingEnabled: false
+        });
+        const subscriberCallback = jest.fn();
+
+        // :: Act
+        const subscriberId = addLogSubscriber(subscriberCallback);
+        logInfo('Hello');
+        logWarn('World');
+        logError('!');
+
+        // :: Assert
+        expect(subscriberCallback).toBeCalledTimes(3);
+        expect(subscriberCallback).toBeCalledWith(['Hello']);
+        expect(subscriberCallback).toBeCalledWith(['World']);
+        expect(subscriberCallback).toBeCalledWith(['!']);
+
+        expect(subscriberId).toBeGreaterThan(0);
+    });
+
+    it('removeLogSubscriber prevents further notifications from being received', () => {
+        // :: Arrange
+        setLoggerConfiguration({
+            isEnabled: true,
+            isDevelopment: false,
+            logWithStackTrace: false,
+            notifyLogSubscribers: true,
+            isMSALLoggingEnabled: false
+        });
+        const subscriberCallback = jest.fn();
+
+        // :: Act
+        const subscriberId = addLogSubscriber(subscriberCallback);
+        removeLogSubscriber(subscriberId);
+        logInfo('Hello');
+        logWarn('World');
+        logError('!');
+
+        // :: Assert
+        expect(subscriberCallback).not.toBeCalled();
+    });
+});

--- a/src/utils/classObserver.ts
+++ b/src/utils/classObserver.ts
@@ -1,0 +1,66 @@
+export type ObserverIdentifier = number;
+
+/**
+ * The interface to implement if one wants to use a subscriber pattern on the implementing class.
+ */
+export interface ObserverInterface {
+    id: ObserverIdentifier;
+    callback: Function;
+    type: string;
+}
+
+/**
+ * Utility class to ease usage of a subscription pattern - i.e. if one needs to have subscriptions (callable functions)
+ * from consumers, this helper class will handle it, ensuring that subscribers are being persisted and notified when
+ * required.
+ * 
+ * The class was copied as-is from EchoCore and was written by Hanne Kottum - all credits to her.
+ */
+class ClassObserver {
+    private id: ObserverIdentifier;
+    private observers: ObserverInterface[];
+
+    constructor() {
+        this.id = 0;
+        this.observers = [];
+    }
+
+    /**
+     * Add a subscriber to the observer.
+     * Later the implementing class can call {@link notify} to notify all subscribers of a given type. 
+     * @param callback the callback function to be called on {@link notify}
+     * @param type the "type" of subscriber
+     * @returns {@link ObserverIdentifier}, a unique id identifying the subscriber
+     */
+    addSubscriber(callback: Function, type: string): ObserverIdentifier {
+        this.id++;
+        const functionCallback = { id: this.id, callback, type };
+        this.observers.push(functionCallback);
+        return this.id;
+    }
+
+    /**
+     * Remove the given subscriber from receiving further notifications.
+     * @param id the {@link ObserverIdentifier} of the subscriber, as obtained from {@link addSubscriber}
+     */
+    removeSubscriber(id: ObserverIdentifier): void {
+        this.observers = this.observers.filter((item) => item.id !== id);
+    }
+
+    /**
+     * Notify any subscribers with the given type and using the given data.
+     * @param data The data to use as a parameter in the callback function for the subscribers,
+     * @param type The type of subscriber
+     */
+    notify<T>(data: T, type: string): void {
+        this.observers.forEach((observer) => {
+            if (observer.type === type) {
+                observer.callback(data);
+            }
+        });
+    }
+}
+
+export default new ClassObserver();
+
+export const ObserverClass = ClassObserver;

--- a/src/utils/formatTimeHelpers.ts
+++ b/src/utils/formatTimeHelpers.ts
@@ -1,0 +1,92 @@
+export function diffHours(dt2: Date, dt1: Date): number | undefined {
+    dt2 = new Date(dt2); //handle strings disguised as dates after JSON parsing
+    dt1 = new Date(dt1);
+    if (isNaN(dt2.getHours()) || isNaN(dt1.getHours())) {
+        return undefined;
+    }
+    let diff = (dt2.getTime() - new Date(dt1).getTime()) / 1000;
+    diff /= 60 * 60;
+    return Math.abs(Math.round(diff));
+}
+
+export function diffMinutes(dt2: Date, dt1: Date): number | undefined {
+    dt2 = new Date(dt2); //handle strings disguised as dates after JSON parsing
+    dt1 = new Date(dt1);
+    if (isNaN(dt2.getHours()) || isNaN(dt1.getHours())) {
+        return undefined;
+    }
+    let diff = (dt2.getTime() - dt1.getTime()) / 1000;
+    diff /= 60;
+    return Math.abs(Math.round(diff));
+}
+
+/**
+ * Returns the elapsed time in seconds between start and end time.
+ * @param startTimeMs The start time to measure elapsed time from in milliseconds.
+ * @param startTimeMs The end time to measure elapsed time to in milliseconds.
+ */
+export function elapsedTimeInSecondsBetween(startTimeMs: number, endTimeMs: number): number {
+    if (startTimeMs > endTimeMs) {
+        const swapEndTime = endTimeMs;
+        endTimeMs = startTimeMs;
+        startTimeMs = swapEndTime;
+    }
+    return (endTimeMs - startTimeMs) / 1000;
+}
+
+/**
+ * Returns the elapsed time since startTime in seconds.
+ * @param startTimeMs The start time to measure elapsed time from in milliseconds.
+ */
+export function ElapsedTimeInSeconds(startTimeMs: number): number {
+    return elapsedTimeInSecondsBetween(performance.now(), startTimeMs);
+}
+
+/**
+ * Returns the elapsed time since startTime in seconds, rounded to specified fixed number of decimal places.
+ * @param startTimeMs The start time to measure elapsed time from.
+ * @param decimalPlaces Number of decimal places.
+ */
+export function ElapsedTimeInSecondsToFixed(startTimeMs: number, decimalPlaces = 2): number {
+    const seconds = ElapsedTimeInSeconds(startTimeMs);
+    const secondsFixedDecimals = Number(Math.round(parseFloat(seconds + 'e' + decimalPlaces)) + 'e-' + decimalPlaces); //https://stackoverflow.com/questions/6134039/format-number-to-always-show-2-decimal-places
+    return secondsFixedDecimals;
+}
+
+/**
+ * Returns a date as a friendly readable string. If the date is undefined, it returns empty string.
+ * @param date The date to convert to friendly string format.
+ */
+export function dateToStringOrEmpty(date: Date | string | undefined): string {
+    const empty = '';
+    if (!date) {
+        return empty;
+    }
+    if (typeof date === 'string') {
+        date = new Date(date);
+    }
+
+    const dateFormatEnGb = 'en-GB';
+    const dateString = date.toLocaleDateString(dateFormatEnGb);
+    if (dateString.toLowerCase().includes('invalid date')) {
+        return dateString;
+    }
+    if (isEpochDateTime(date)) {
+        return empty;
+    }
+
+    const timeString = date.toLocaleTimeString(dateFormatEnGb, { hour12: false });
+    if (timeString === '00:00:00' || timeString === '24:00:00') {
+        return dateString;
+    }
+    return dateString + ' ' + timeString;
+}
+
+/**
+ * Returns true if the specified date is 1-1-1970
+ * @param date the date to check.
+ */
+function isEpochDateTime(date: Date): boolean {
+    const time = date.toUTCString();
+    return time === 'Thu, 01 Jan 1970 00:00:00 GMT';
+}

--- a/src/utils/formatTimeHelpers.ts
+++ b/src/utils/formatTimeHelpers.ts
@@ -38,7 +38,7 @@ export function elapsedTimeInSecondsBetween(startTimeMs: number, endTimeMs: numb
  * Returns the elapsed time since startTime in seconds.
  * @param startTimeMs The start time to measure elapsed time from in milliseconds.
  */
-export function ElapsedTimeInSeconds(startTimeMs: number): number {
+export function elapsedTimeInSeconds(startTimeMs: number): number {
     return elapsedTimeInSecondsBetween(performance.now(), startTimeMs);
 }
 
@@ -47,8 +47,8 @@ export function ElapsedTimeInSeconds(startTimeMs: number): number {
  * @param startTimeMs The start time to measure elapsed time from.
  * @param decimalPlaces Number of decimal places.
  */
-export function ElapsedTimeInSecondsToFixed(startTimeMs: number, decimalPlaces = 2): number {
-    const seconds = ElapsedTimeInSeconds(startTimeMs);
+export function elapsedTimeInSecondsToFixed(startTimeMs: number, decimalPlaces = 2): number {
+    const seconds = elapsedTimeInSeconds(startTimeMs);
     const secondsFixedDecimals = Number(Math.round(parseFloat(seconds + 'e' + decimalPlaces)) + 'e-' + decimalPlaces); //https://stackoverflow.com/questions/6134039/format-number-to-always-show-2-decimal-places
     return secondsFixedDecimals;
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -84,7 +84,7 @@ export function logError(...args: any[]): void {
     localLog(LogType.Error, ...args);
 }
 
-const isMac = (): boolean => {
+const isIOS = (): boolean => {
     const mac = /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform);
     return mac;
 };
@@ -97,7 +97,7 @@ function getStackCallerFunctionName(err: any): string {
         : err.stack.includes('logPerformanceToConsole')
         ? err.stack.split('\n')[4]
         : err.stack.split('\n')[3];
-    if (!isMac() && String(caller).includes('at')) caller = caller.split('at ')[1].split(' (')[0];
+    if (!isIOS() && String(caller).includes('at')) caller = caller.split('at ')[1].split(' (')[0];
     return caller;
 }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,5 +1,5 @@
 import { ObserverClass, ObserverIdentifier } from './classObserver';
-import { ElapsedTimeInSeconds } from './formatTimeHelpers';
+import { elapsedTimeInSeconds } from './formatTimeHelpers';
 
 /**
  * Log configuration
@@ -130,7 +130,7 @@ function logWithType(logType: LogType, ...args: any[]): void {
 }
 
 export function logPerformanceToConsole(message: string, startTime: number): void {
-    const timeInSeconds = ElapsedTimeInSeconds(startTime);
+    const timeInSeconds = elapsedTimeInSeconds(startTime);
     let color = 'green';
     if (timeInSeconds > 0.3) color = 'orange';
     if (timeInSeconds > 1) color = 'red';

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -30,19 +30,19 @@ const logSubscribers : LogSubscribers = new LogSubscribers();
  * The interface for the callback function used for subscribers, @see{addLogSubscriber}.
  *
  * @export
- * @interface CallbackFunction
+ * @interface SubscriberCallbackFunction
  */
-export interface CallbackFunction {
+export interface SubscriberCallbackFunction {
     (logOutput: string) : void;
 }
 
 /**
  * Add a subscriber to the given type. If the configuration is setup to notify subscribers, then the callback
  * given here will be called if a logging is performed on the given type.
- * @param callback 
+ * @param callback {@link SubscriberCallbackFunction}, the function that will be called on log events.
  * @returns a unique identifier for the subscriber which later can be used in {@link removeLogSubscriber}.
  */
-export function addLogSubscriber(callback: CallbackFunction) : ObserverIdentifier {
+export function addLogSubscriber(callback: SubscriberCallbackFunction) : ObserverIdentifier {
     return logSubscribers.addSubscriber(callback, LogSubscriberType);
 }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,139 @@
+import { ObserverClass, ObserverIdentifier } from './classObserver';
+import { ElapsedTimeInSeconds } from './formatTimeHelpers';
+
+/**
+ * Log configuration
+ */
+ let config = {
+    isEnabled: false,
+    logWithStackTrace: false,
+    notifyLogSubscribers: false,
+    isDevelopment: false,
+    isMSALLoggingEnabled: false
+} as LoggerConfiguration;
+
+/**
+ * Internal helper class to keep track of any log-subscribers.
+ */
+class LogSubscribers extends ObserverClass {
+    constructor() {
+        super();
+    }
+}
+// The ObserverClass needs a "type" on each subscription. Consumers of the logger (i.e. logSubscriptions) do not 
+// need to know about this and we just assign the same "type" to all subscribers; this one. 
+const LogSubscriberType : string  = 'LogSubscriberType';
+const logSubscribers : LogSubscribers = new LogSubscribers();
+
+/**
+ * Add a subscriber to the given type. If the configuration is setup to notify subscribers, then the callback
+ * given here will be called if a logging is performed on the given type.
+ * @param callback 
+ * @returns a unique identifier for the subscriber which later can be used in {@link removeLogSubscriber}.
+ */
+export function addLogSubscriber(callback: Function) : ObserverIdentifier {
+    return logSubscribers.addSubscriber(callback, LogSubscriberType);
+}
+
+/**
+ * Remove the given log-subscriber from receiving any further log-notifications.
+ * @param identifier The identifier as obtained from {@link addLogSubscriber}
+ */
+export function removeLogSubscriber(identifier : ObserverIdentifier) {
+    logSubscribers.removeSubscriber(identifier);
+}
+
+export interface LoggerConfiguration {
+    isEnabled: boolean;
+    isDevelopment: boolean;
+    logWithStackTrace: boolean;
+    notifyLogSubscribers: boolean;
+    isMSALLoggingEnabled: boolean;
+}
+
+export function setLoggerConfiguration(loggerConfiguration: LoggerConfiguration): void {
+    config = loggerConfiguration;
+}
+
+enum LogType {
+    Info,
+    Warn,
+    Error,
+    Verbose
+}
+
+export function logMSAL(...args: any[]): void {
+    if (config.isMSALLoggingEnabled) {
+        localLog(LogType.Info, ...args);
+    }
+}
+
+export function logVerbose(...args: any[]): void {
+    localLog(LogType.Verbose, ...args);
+}
+
+export function logInfo(...args: any[]): void {
+    localLog(LogType.Info, ...args);
+}
+
+export function logWarn(...args: any[]): void {
+    localLog(LogType.Warn, ...args);
+}
+
+export function logError(...args: any[]): void {
+    localLog(LogType.Error, ...args);
+}
+
+const isMac = (): boolean => {
+    const mac = /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform);
+    return mac;
+};
+
+function getStackCallerFunctionName(err: any): string {
+    let caller = err.stack.includes('logErrorToAppInsights')
+        ? err.stack.split('\n')[9]
+        : err.stack.includes('postNotification')
+        ? err.stack.split('\n')[6]
+        : err.stack.includes('logPerformanceToConsole')
+        ? err.stack.split('\n')[4]
+        : err.stack.split('\n')[3];
+    if (!isMac() && String(caller).includes('at')) caller = caller.split('at ')[1].split(' (')[0];
+    return caller;
+}
+
+function localLog(logType: LogType, ...args: any[]): void {
+    if (!config.isEnabled) {
+        return;
+    }
+    
+    if (config.notifyLogSubscribers) {
+        logSubscribers.notify(args, LogSubscriberType);
+    }
+
+    if (config.logWithStackTrace && config.isDevelopment) {
+        try {
+            throw new Error();
+        } catch (err) {
+            const callerName = getStackCallerFunctionName(err);
+            logWithType(logType, ...args, `[${callerName}]`); //callerName at the end to get colors to work
+        }
+    } else {
+        logWithType(logType, ...args);
+    }
+}
+
+function logWithType(logType: LogType, ...args: any[]): void {
+    if (logType === LogType.Info) console.log(...args);
+    else if (logType === LogType.Warn) console.warn(...args);
+    else if (logType === LogType.Error) console.error(...args);
+    else if (logType === LogType.Verbose) console.log(...args);
+}
+
+export function logPerformanceToConsole(message: string, startTime: number): void {
+    const timeInSeconds = ElapsedTimeInSeconds(startTime);
+    let color = 'green';
+    if (timeInSeconds > 0.3) color = 'orange';
+    if (timeInSeconds > 1) color = 'red';
+
+    logVerbose('%c%s %c%s', `color: black;`, message, `color: ${color};`, timeInSeconds.toFixed(3) + ' sec(s)');
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -25,13 +25,24 @@ class LogSubscribers extends ObserverClass {
 const LogSubscriberType : string  = 'LogSubscriberType';
 const logSubscribers : LogSubscribers = new LogSubscribers();
 
+
+/**
+ * The interface for the callback function used for subscribers, @see{addLogSubscriber}.
+ *
+ * @export
+ * @interface CallbackFunction
+ */
+export interface CallbackFunction {
+    (logOutput: string) : void;
+}
+
 /**
  * Add a subscriber to the given type. If the configuration is setup to notify subscribers, then the callback
  * given here will be called if a logging is performed on the given type.
  * @param callback 
  * @returns a unique identifier for the subscriber which later can be used in {@link removeLogSubscriber}.
  */
-export function addLogSubscriber(callback: Function) : ObserverIdentifier {
+export function addLogSubscriber(callback: CallbackFunction) : ObserverIdentifier {
     return logSubscribers.addSubscriber(callback, LogSubscriberType);
 }
 


### PR DESCRIPTION
Moving/copying the logger utility from EchoWeb.
In doing so one also needs to copy over the TimeUtils from EchoWeb and ClassObserver from EchoCore.

Test coverage was somewhat lacking on these utils, so have added those too.


Still need to see if further refactoring of the logger will be needed, to avoid dependecy on the TimeUtils.