### PR TITLE
Echo utils export of observerClass and others.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-utils",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "description": "Utils and hooks for echo web project",
     "main": "dist/index.js",
     "types": "dist/types/index.d.ts",

--- a/src/__tests__/hooks/useWindowSize.test.tsx
+++ b/src/__tests__/hooks/useWindowSize.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent } from '@testing-library/dom';
 import { act, renderHook } from '@testing-library/react-hooks';
-import { useWindowSize } from '../..';
+import { useWindowSize } from '../../hooks';
 
 // Inspired from https://alexboffey.co.uk/blog/jest-window-mock/
 describe('useWindowSize', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,14 @@
  * Expose utils and hooks here
  */
 
-export * from './hooks';
-export * from './types';
-export * from './utils';
+import * as hooks from './hooks';
+import * as types from './types';
+import * as utils from './utils';
+
+export const EchoUtils = {
+    Hooks: hooks,
+    Types: types,
+    Utils: utils
+};
+
+export default EchoUtils;


### PR DESCRIPTION
```
EchoUtils.Utils.ObserverClass
```

EchoUtils har ikke exportert ObserverClass

Forslag: å la alle exports tilhører sin logiske context.
Bør gjøres for Core, etc også.

Så istedenfor å at man ser ObserverClass i koden på linje 57, så ser man EchoUtils.Utils.ObserverClass. Da er det så mye lettere å holde styr og se sammenhengen når man leser kode syns jeg, og enklere å lage bilde i hodet.

Hva tenker dere?, og skal det hete EchoUtils.utils.ObserverClass eller EchoUtils.Utils.ObserverClass? Jeg selv foretrekker stor bokstav, men kanskje det er annen standard her i typescript verden?