### PR TITLE
fix: Make filter keys order insensitive

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-utils",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "Utils and hooks for echo web project",
     "main": "dist/index.js",
     "types": "dist/types/index.d.ts",

--- a/src/__tests__/filterUtils.test.ts
+++ b/src/__tests__/filterUtils.test.ts
@@ -4,21 +4,24 @@ const object1 = {
     prop1: 'prop1',
     prop2: 'prop2',
     prop3: 3,
-    prop4: new Date(2018, 11, 24, 10, 33, 30, 0)
+    prop4: new Date(2018, 11, 24, 10, 33, 30, 0),
+    propObj: {}
 };
 
 const object2 = {
     prop1: 'prop1',
     prop2: 'prop2',
     prop3: 'prop3',
-    prop4: new Date(2019, 11, 24, 10, 33, 30, 0)
+    prop4: new Date(2019, 11, 24, 10, 33, 30, 0),
+    propObj: {}
 };
 
 const object3 = {
     prop1: 'prop1',
     prop2: 'prop3',
     prop3: true,
-    prop4: new Date(2020, 11, 24, 10, 33, 30, 0)
+    prop4: new Date(2020, 11, 24, 10, 33, 30, 0),
+    propObj: {}
 };
 
 describe('filterOnProps', () => {
@@ -59,7 +62,7 @@ describe('filterOnProps', () => {
     it('if the provided filter only has one matching key, it should only consider that key when filtering', () => {
         const data = [object1, object2, object3];
 
-        const filteredData = filterOnProps(data, { prop4: 'prop3', prop5: 'prop99', prop3: true });
+        const filteredData = filterOnProps(data, { prop6: 'prop3', prop5: 'prop99', prop3: true });
         expect(filteredData).toEqual([object3]);
     });
 });

--- a/src/__tests__/filterUtils.test.ts
+++ b/src/__tests__/filterUtils.test.ts
@@ -4,24 +4,21 @@ const object1 = {
     prop1: 'prop1',
     prop2: 'prop2',
     prop3: 3,
-    prop4: new Date(2018, 11, 24, 10, 33, 30, 0),
-    propObj: {}
+    prop4: new Date(2018, 11, 24, 10, 33, 30, 0)
 };
 
 const object2 = {
     prop1: 'prop1',
     prop2: 'prop2',
     prop3: 'prop3',
-    prop4: new Date(2019, 11, 24, 10, 33, 30, 0),
-    propObj: {}
+    prop4: new Date(2019, 11, 24, 10, 33, 30, 0)
 };
 
 const object3 = {
     prop1: 'prop1',
     prop2: 'prop3',
     prop3: true,
-    prop4: new Date(2020, 11, 24, 10, 33, 30, 0),
-    propObj: {}
+    prop4: new Date(2020, 11, 24, 10, 33, 30, 0)
 };
 
 describe('filterOnProps', () => {

--- a/src/__tests__/utils/filterUtils.test.ts
+++ b/src/__tests__/utils/filterUtils.test.ts
@@ -1,4 +1,4 @@
-import { filterOnProps } from '../utils/filterUtils';
+import { filterOnProps } from '../../utils/filterUtils';
 
 const object1 = {
     prop1: 'prop1',

--- a/src/utils/filterUtils.ts
+++ b/src/utils/filterUtils.ts
@@ -14,9 +14,9 @@ interface Filter {
  */
 export function filterOnProps<T>(data: T[], propsToFilterOn: Filter): T[] {
     const filters = Object.keys(propsToFilterOn);
-    let filteredData: T[] = [];
+    let filterData: T[] = data;
     for (const filter of filters) {
-        filteredData = data.filter((d) => {
+        filterData = filterData.filter((d) => {
             if (typeof d === 'object' && d !== null && !Array.isArray(d)) {
                 if ((d as Record<string, unknown>).hasOwnProperty(filter)) {
                     const filterValueFromData = (d as Record<string, unknown>)[filter];
@@ -28,5 +28,5 @@ export function filterOnProps<T>(data: T[], propsToFilterOn: Filter): T[] {
             }
         });
     }
-    return filteredData;
+    return filterData;
 }


### PR DESCRIPTION
There was a bug where the order of the filters you put in could have an impact on the result. Fixed this.