### PR TITLE
feat(#64909): Add hook for altering tab titles

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -8,6 +8,5 @@ export { useIsSmallScreen } from './useIsSmallScreen';
 export * from './useNavigatorOnline';
 export { useOnOutsideClick } from './useOnOutsideClick';
 export { usePing } from './usePing';
-export { useTabTitle } from "./useTabTitle";
+export { useTabTitle } from './useTabTitle';
 export { useWindowSize } from './useWindowSize';
-

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -8,4 +8,6 @@ export { useIsSmallScreen } from './useIsSmallScreen';
 export * from './useNavigatorOnline';
 export { useOnOutsideClick } from './useOnOutsideClick';
 export { usePing } from './usePing';
+export { useTabTitle } from "./useTabTitle";
 export { useWindowSize } from './useWindowSize';
+

--- a/src/hooks/useTabTitle.ts
+++ b/src/hooks/useTabTitle.ts
@@ -6,7 +6,7 @@ import { useInitial } from '../hooks';
  */
 export function useTabTitle(title: string): void {
     useInitial(() => {
-        const previousTitle = globalThis.document.title;
+        const previousTitle = window.document.title;
         window.document.title = title;
 
         return () => {

--- a/src/hooks/useTabTitle.ts
+++ b/src/hooks/useTabTitle.ts
@@ -1,0 +1,16 @@
+import { useInitial } from "../hooks";
+
+/**
+ * Sets the provided string as the tab or window title. 
+ * The hook will set the previous title when the component is unmounted. 
+ */
+export function useTabTitle(title: string): void {
+    useInitial(() => {
+        const previousTitle = globalThis.document.title;
+        globalThis.document.title = title;
+    
+        return () => {
+          globalThis.document.title = previousTitle;
+        };
+      });
+}

--- a/src/hooks/useTabTitle.ts
+++ b/src/hooks/useTabTitle.ts
@@ -1,16 +1,16 @@
-import { useInitial } from "../hooks";
+import { useInitial } from '../hooks';
 
 /**
- * Sets the provided string as the tab or window title. 
- * The hook will set the previous title when the component is unmounted. 
+ * Sets the provided string as the tab or window title.
+ * The hook will set the previous title when the component is unmounted.
  */
 export function useTabTitle(title: string): void {
     useInitial(() => {
         const previousTitle = globalThis.document.title;
         globalThis.document.title = title;
-    
+
         return () => {
-          globalThis.document.title = previousTitle;
+            globalThis.document.title = previousTitle;
         };
-      });
+    });
 }

--- a/src/hooks/useTabTitle.ts
+++ b/src/hooks/useTabTitle.ts
@@ -7,10 +7,10 @@ import { useInitial } from '../hooks';
 export function useTabTitle(title: string): void {
     useInitial(() => {
         const previousTitle = globalThis.document.title;
-        globalThis.document.title = title;
+        window.document.title = title;
 
         return () => {
-            globalThis.document.title = previousTitle;
+            window.document.title = previousTitle;
         };
     });
 }


### PR DESCRIPTION
## Prerequisites

Please make sure you can check the following boxes:

-   [x] My code follows the code style of this project
-   [x] All new and existing tests passed _(No tests are added as there is no new logic to test)_
-   [x] Fix any eslint/prettier warnings/errors: npm run lint
-   [x] Remove unnecessary console.log (use logInfo logWarn if it's needed)
-   [x] Are variable and function names properly describing what it does?

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

-   [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
-   [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] I have updated the documentation accordingly
-   [ ] I have added tests to cover my changes

### Description

This PR adds a hook that will takes a string and edits document.title. It will take a copy of the previous title and replace it when the component is unmounted.

### Remarks
_No tests are added as there is no new logic to test._
