### PR TITLE
fix: remove module from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "main": "dist/index.js",
     "types": "dist/types/index.d.ts",
     "source": "src/index.ts",
-    "module": "true",
     "scripts": {
         "build": "rollup -c",
         "build-watch": "rollup -c -w ",


### PR DESCRIPTION

## Prerequisites

Please make sure you can check the following boxes:

-   [x] My code follows the code style of this project
-   [x] All new and existing tests passed
-   [x] Fix any eslint/prettier warnings/errors: npm run lint
-   [x] Remove unnecessary console.log (use logInfo logWarn if it's needed)
-   [x] Are variable and function names properly describing what it does?

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

-   [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
-   [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] I have updated the documentation accordingly
-   [ ] I have added tests to cover my changes

### Description

Module is not a bool, its the entry point of the module. This breaks package managers and build tools depending on a valid value in the module field.

module field is not official in node, and using "main" should be fine for this package since its a commonjs package.


### Remarks

N/A
